### PR TITLE
CVS-100 スキーマ定義の修正

### DIFF
--- a/src/v1.json
+++ b/src/v1.json
@@ -74,7 +74,7 @@
                     "vms": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/vm"
+                        "$ref": "#/components/schemas/Vm"
                       }
                     }
                   },
@@ -82,7 +82,31 @@
                     "vms"
                   ]
                 },
-                "examples": {}
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "vms": [
+                        {
+                          "name": "ubuntu",
+                          "metadata": {
+                            "id": "4e0a3c48-f483-422a-b520-2820207cef42",
+                            "api_version": "v1"
+                          },
+                          "memory": 2048,
+                          "vcpu": 4,
+                          "devices": {
+                            "disk": [
+                              {
+                                "type": "qcow2",
+                                "path": "/var/lib/libvirt/images/ubuntu22.04.qcow2"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
               }
             }
           }
@@ -117,9 +141,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/vm"
+                  "$ref": "#/components/schemas/Vm"
                 },
-                "examples": {}
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "name": "ubuntu",
+                      "metadata": {
+                        "id": "4e0a3c48-f483-422a-b520-2820207cef42",
+                        "api_version": "v1"
+                      },
+                      "memory": 2048,
+                      "vcpu": 4,
+                      "devices": {
+                        "disk": [
+                          {
+                            "type": "qcow2",
+                            "path": "/var/lib/libvirt/images/ubuntu22.04.qcow2"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -185,15 +229,15 @@
                   "type": "object",
                   "properties": {
                     "cpu": {
-                      "$ref": "#/components/schemas/cpu"
+                      "$ref": "#/components/schemas/Cpu"
                     },
                     "mem": {
-                      "$ref": "#/components/schemas/memory"
+                      "$ref": "#/components/schemas/Memory"
                     },
                     "storage_pools": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/storage_pool"
+                        "$ref": "#/components/schemas/StoragePool"
                       }
                     }
                   },
@@ -203,7 +247,31 @@
                     "storage_pools"
                   ]
                 },
-                "examples": {}
+                "examples": {
+                  "example-1": {
+                    "value": {
+                      "cpu": {
+                        "counts": 4,
+                        "percent": 8
+                      },
+                      "mem": {
+                        "total": 16656519168,
+                        "used": 5022781440,
+                        "free": 6728339456,
+                        "used_percent": 30.1550485388905
+                      },
+                      "storage_pools": [
+                        {
+                          "name": "default",
+                          "total_size": 199239593984,
+                          "used_size": 160473669632,
+                          "path": "/var/lib/libvirt/default",
+                          "status": "Active"
+                        }
+                      ]
+                    }
+                  }
+                }
               }
             }
           }
@@ -216,8 +284,8 @@
   },
   "components": {
     "schemas": {
-      "vm": {
-        "title": "vm",
+      "Vm": {
+        "title": "Vm",
         "type": "object",
         "x-tags": [
           "vm"
@@ -302,8 +370,8 @@
           "devices"
         ]
       },
-      "cpu": {
-        "title": "cpu",
+      "Cpu": {
+        "title": "Cpu",
         "type": "object",
         "x-tags": [
           "host"
@@ -329,8 +397,8 @@
         },
         "description": "ホストのCPU情報"
       },
-      "memory": {
-        "title": "memory",
+      "Memory": {
+        "title": "Memory",
         "type": "object",
         "x-tags": [
           "host"
@@ -366,8 +434,8 @@
         },
         "description": "ホストのメモリ情報"
       },
-      "storage_pool": {
-        "title": "storage_pool",
+      "StoragePool": {
+        "title": "StoragePool",
         "type": "object",
         "x-tags": [
           "host"


### PR DESCRIPTION
1. example を書く
コンポーネントに書かれた example はモックサーバでは取得できなかった
2. コンポーネント名の修正
生成される型をアッパーキャメルにしたいので、コンポーネント名をアッパーキャメルケースにする