### PR TITLE
CVS-160 `used_percent` プロパティを `percent` に修正

### DIFF
--- a/src/v1.json
+++ b/src/v1.json
@@ -232,7 +232,7 @@
             "type": "integer",
             "format": "uint64"
           },
-          "used_percent": {
+          "percent": {
             "type": "number",
             "format": "double"
           }
@@ -241,7 +241,7 @@
           "total",
           "used",
           "free",
-          "used_percent"
+          "percent"
         ]
       },
       "StoragePool": {
@@ -632,7 +632,7 @@
                       "total": 16526876672,
                       "used": 8849772544,
                       "free": 315400192,
-                      "used_percent": 53.54776174371394
+                      "percent": 53.54776174371394
                     },
                     "storage_pools": [
                       {


### PR DESCRIPTION
## 概要

使用率 (%) を表すプロパティが `used_percent` と `percent` で不統一だったのを修正

## 動作テスト方法

モックサーバを立ち上げて curl で動作テスト

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
