### PR TITLE
CVS-173 `memory`, `cpu` プロパティの型に `uint64` を指定

### DIFF
--- a/src/v1.json
+++ b/src/v1.json
@@ -32,10 +32,12 @@
                     "type": "string"
                   },
                   "memory": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "cpu": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   }
                 },
                 "required": [
@@ -119,10 +121,12 @@
                     "type": "string"
                   },
                   "memory": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   },
                   "cpu": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint64"
                   }
                 }
               },


### PR DESCRIPTION
## 概要

backend に生成されるコード中の型定義にて `uint64` を使用するため、型定義を変更

## 動作テスト方法

コードを生成し、models に生成された型定義を確認

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
