### PR TITLE
CVS-173 Vm models の `memory`, `cpu` プロパティの型に `uint64` を指定

### DIFF
--- a/src/v1.json
+++ b/src/v1.json
@@ -233,10 +233,12 @@
             "$ref": "#/components/schemas/Metadata"
           },
           "memory": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "cpu": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "devices": {
             "$ref": "#/components/schemas/Devices"


### PR DESCRIPTION
## 概要

Vm models の型の修正を忘れていたので

## 動作テスト方法

生成される型を確認する

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
