### PR TITLE
CVS-173 `cpu` プロパティの型を int に修正

### DIFF
--- a/src/v1.json
+++ b/src/v1.json
@@ -36,8 +36,7 @@
                     "format": "uint64"
                   },
                   "cpu": {
-                    "type": "integer",
-                    "format": "uint64"
+                    "type": "integer"
                   }
                 },
                 "required": [
@@ -125,8 +124,7 @@
                     "format": "uint64"
                   },
                   "cpu": {
-                    "type": "integer",
-                    "format": "uint64"
+                    "type": "integer"
                   }
                 }
               },
@@ -237,8 +235,7 @@
             "format": "uint64"
           },
           "cpu": {
-            "type": "integer",
-            "format": "uint64"
+            "type": "integer"
           },
           "devices": {
             "$ref": "#/components/schemas/Devices"


### PR DESCRIPTION
## 概要

`cpu` プロパティが uint64 になっていたので int にした

## 動作テスト方法

コードを生成して確認する

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
